### PR TITLE
remove dependency on joda time

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,8 +18,6 @@ lazy val `scala-soap` = project
     libraryDependencies ++= Seq(
       "org.scala-lang.modules"  %% "scala-xml"      % "1.0.6",
       "org.slf4j"               % "slf4j-api"       % "1.7.25",
-      "joda-time"               % "joda-time"       % "2.9.9",
-      "org.joda"                % "joda-convert"    % "1.8.3",
       "org.specs2"              %% "specs2-core"    % "3.9.5" % Test,
       slf4jBind
     )

--- a/scala-soap/src/main/scala/com/sandinh/soap/SOAPDate.scala
+++ b/scala-soap/src/main/scala/com/sandinh/soap/SOAPDate.scala
@@ -1,22 +1,22 @@
 package com.sandinh.soap
 
-import org.joda.time.DateTime
-import org.joda.time.format.DateTimeFormatter
-import org.joda.time.format.ISODateTimeFormat.{yearMonthDay, dateHourMinuteSecond}
+import java.time.{LocalDate, LocalDateTime}
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeFormatter.{ISO_DATE, ISO_LOCAL_DATE_TIME}
 
-class SOAPDate(date: DateTime, dateFormatter: DateTimeFormatter) {
-  override def toString = dateFormatter.print(date)
-  def toDate = date
+class SOAPDate(date: LocalDateTime, dateFormatter: DateTimeFormatter) {
+  override def toString: String = date.format(dateFormatter)
+  def toDate: LocalDateTime = date
 }
 
 object SOAPDate {
-  def apply(date: DateTime) = new SOAPDate(date, dateHourMinuteSecond)
-  def apply(dateText: String) = new SOAPDate(textToDate(dateText), dateHourMinuteSecond)
+  def apply(date: LocalDateTime) = new SOAPDate(date, ISO_LOCAL_DATE_TIME)
+  def apply(dateText: String) = new SOAPDate(textToDate(dateText), ISO_LOCAL_DATE_TIME)
 
-  def textToDate(dateText: String): DateTime = {
+  def textToDate(dateText: String): LocalDateTime = {
     if (dateText.length == 10) //"yyyy-MM-dd".length
-      yearMonthDay.parseDateTime(dateText)
+      LocalDate.parse(dateText, ISO_DATE).atStartOfDay()
     else
-      dateHourMinuteSecond.parseDateTime(dateText)
+      LocalDateTime.parse(dateText, ISO_LOCAL_DATE_TIME)
   }
 }

--- a/scala-soap/src/test/scala/SOAPDateSpec.scala
+++ b/scala-soap/src/test/scala/SOAPDateSpec.scala
@@ -1,12 +1,15 @@
 import org.specs2.mutable._
 import com.sandinh.soap.SOAPDate
-import org.joda.time.{DateTimeZone, DateTime}
+import java.time.LocalDateTime
+import java.time.Instant.EPOCH
+import java.time.ZoneOffset.UTC
+import java.time.format.DateTimeParseException
 
 class SOAPDateSpec extends Specification {
 
   "SOAPDate" should {
 
-    "parse SOAP format date yyyy-MM-dd'T'HH:mm:ss" in {
+    "parse SOAP format datetime yyyy-MM-dd'T'HH:mm:ss" in {
       SOAPDate("1970-01-01T00:00:01").toString === "1970-01-01T00:00:01"
       SOAPDate("1970-02-01T00:00:00").toString === "1970-02-01T00:00:00"
       SOAPDate("1970-01-01T00:00:00").toString === "1970-01-01T00:00:00"
@@ -16,12 +19,12 @@ class SOAPDateSpec extends Specification {
       SOAPDate("1970-01-01").toString === "1970-01-01T00:00:00"
     }
 
-    "parse SOAP format new DateTime from UNIX 0" in {
-      SOAPDate(new DateTime(0L, DateTimeZone.UTC)).toString === "1970-01-01T00:00:00"
+    "parse SOAP format LocalDateTime from UNIX 0" in {
+      SOAPDate(LocalDateTime.ofInstant(EPOCH, UTC)).toString === "1970-01-01T00:00:00"
     }
 
-    "throw IllegalArgumentException on invalid format" in {
-      SOAPDate("bzdura") must throwA[IllegalArgumentException]
+    "throw DateTimeParseException on invalid format" in {
+      SOAPDate("bzdura") must throwA[DateTimeParseException]
     }
   }
 }


### PR DESCRIPTION
- replace joda's `DateTime` with java.time's `LocalDateTime`
- remove `joda-time` and `joda-convert` dependencies

Note: SOAPDate still does not support time zones 

Alternatively to SOAPDate we could consider explicit `XmlConverter`. 

`XmlConverter[LocalDate]` for `xs:date`
and 
`XmlConverter[LocalDateTime]` for `xs:datetime`